### PR TITLE
instmods: check modules.builtin in $srcmods

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -1137,7 +1137,7 @@ instmods() {
                     return 0
                 fi
 
-                if grep -q "/${_mod}.ko" /lib/modules/$kernel/modules.builtin; then
+                if grep -q "/${_mod}.ko" $srcmods/modules.builtin; then
                     # Module is built-in
                     return 0
                 fi


### PR DESCRIPTION
Running dracut with --kmoddir causes lots of errors like this:

grep: /lib/modules/4.4.73-default/modules.builtin: No such file or directory

Fix this by looking up modules.builtin in the proper path.