### PR TITLE
dracut-init.sh: ignore crc32.ko in builtin test

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -1137,7 +1137,7 @@ instmods() {
                     return 0
                 fi
 
-                if grep -q "/${_mod}.ko" $srcmods/modules.builtin; then
+                if [[ ${_mod} != crc32 ]] && grep -q "/${_mod}.ko" $srcmods/modules.builtin; then
                     # Module is built-in
                     return 0
                 fi

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -119,7 +119,7 @@ install() {
 
     inst_rules 40-multipath.rules 56-multipath.rules \
 	62-multipath.rules 65-multipath.rules \
-	66-kpartx.rules 67-kpartx-compat.rules \
+	66-kpartx.rules \
 	11-dm-mpath.rules
 }
 


### PR DESCRIPTION
crc32.ko exists twice in certain kernels (e.g. SLE12): as
/kernel/lib/crc32.ko (SLE12: builtin) and as kernel/crypto/crc32.ko
(SLE12: module). When the latter module is necessary, dracut
falsely classifies it as builtin. Fix that.