### PR TITLE
95nfs: If no server is configured, read BOOTSERVERADDR from wicked's leaseinfo

### DIFF
--- a/modules.d/95nfs/nfs-lib.sh
+++ b/modules.d/95nfs/nfs-lib.sh
@@ -106,7 +106,7 @@ anaconda_nfsv6_to_var() {
 # fill in missing server/path from DHCP options.
 nfsroot_from_dhcp() {
     local f
-    for f in /tmp/net.$1.override /tmp/dhclient.$1.dhcpopts; do
+    for f in /tmp/net.$1.override /tmp/dhclient.$1.dhcpopts /tmp/leaseinfo.$1.dhcp.*; do
         [ -f $f ] && . $f
     done
     [ -n "$new_root_path" ] && nfsroot_to_var "$nfs:$new_root_path"
@@ -114,6 +114,7 @@ nfsroot_from_dhcp() {
     [ -z "$server" ] && server=$srv
     [ -z "$server" ] && server=$new_dhcp_server_identifier
     [ -z "$server" ] && server=$new_next_server
+    [ -z "$server" ] && server=$BOOTSERVERADDR
     [ -z "$server" ] && server=${new_root_path%%:*}
 }
 


### PR DESCRIPTION
References: boo#1089332